### PR TITLE
Change extendFields to extendFieldsBefore

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -116,8 +116,21 @@ class Plugin extends PluginBase
             }
 
         });
-    }
 
+        \Cms\Classes\Page::extend(function($model){
+            $model->translatable =  array_merge($model->translatable, $this->seoFieldsToTranslate());
+            //$model->addDynamicProperty('translatable', $this->seoFieldsToTranslate() + 'title' ); 
+        });
+    }
+    private function seoFieldsToTranslate(){
+        $toTrans = [];
+        foreach($this->seoFields() as $fieldKey => $fieldValue){
+            if(isset($fieldValue['trans']) && $fieldValue['trans'] == true){
+                $toTrans[] = $fieldKey;
+            }
+        }
+        return $toTrans;
+    }
     
     private function blogSeoFields() {
         return collect($this->seoFields())->mapWithKeys(function($item, $key) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -81,7 +81,7 @@ class Plugin extends PluginBase
 
     public function register()
     {
-        \Event::listen('backend.form.extendFields', function($widget)
+        \Event::listen('backend.form.extendFieldsBefore', function($widget)
         {
             if ($widget->isNested === false ) {
             
@@ -91,30 +91,28 @@ class Plugin extends PluginBase
                 if ( PluginManager::instance()->hasPlugin('RainLab.Pages') 
                     && $widget->model instanceof \RainLab\Pages\Classes\Page) {  
                         
-                    $widget->removeField('viewBag[meta_title]' );
-                    $widget->removeField('viewBag[meta_description]');
-                    $widget->addFields( array_except($this->staticSeoFields(), [
+                    $widget->tabs['fields'] =array_replace($widget->tabs['fields'], array_except($this->staticSeoFields(), [
                         'viewBag[model_class]', 
-                    ]), 'primary'); 
+                    ])); 
                 }
             
                 if ( PluginManager::instance()->hasPlugin('RainLab.Blog') 
                     && $widget->model instanceof \RainLab\Blog\Models\Post) {
 
-                        $widget->addFields( array_except($this->blogSeoFields(), [
+                        $widget->tabs['fields'] = array_replace($widget->tabs['fields'], array_except($this->blogSeoFields(), [
                             'arcane_seo_options[model_class]', 
                             'arcane_seo_options[lastmod]', 
                             'arcane_seo_options[use_updated_at]', 
                             'arcane_seo_options[changefreq]', 
                             'arcane_seo_options[priority]'
-                        ]), 'secondary');
+                        ]));
                 }
                 
                 if (!$widget->model instanceof \Cms\Classes\Page) return;
                 
-                $widget->removeField('settings[meta_title]');
-                $widget->removeField('settings[meta_description]');
-                $widget->addFields( $this->cmsSeoFields(), 'primary');
+                $widget->tabs['fields'] = array_replace($widget->tabs['fields'], $this->cmsSeoFields());
+
+                
             }
 
         });

--- a/config/seofields.yaml
+++ b/config/seofields.yaml
@@ -4,6 +4,7 @@ meta_title :
   span: full
   tab: Meta
   comment : Page title
+  trans: true
   attributes: 
     data-counter: 1
     data-min: 30
@@ -18,6 +19,7 @@ meta_description:
     tab: Meta
     cssClass: char-counter
     comment: Page description
+    trans: true
     attributes: 
       data-counter: 1 
       data-min: 100 
@@ -29,6 +31,7 @@ canonical_url:
     type: text
     tab: Meta
     span: full
+    trans: true
     comment: The canonical URL this page should point to defaults to current URL
 
 robot_index: 
@@ -139,6 +142,7 @@ og_title :
     label   : og:title (dynamic)
     tab     : Open Graph
     span    : auto
+    trans: true
     comment : Recommended 50-60 characters
     placeholder: Defaults to SEO if left blank
 
@@ -148,6 +152,7 @@ og_description :
     type : textarea
     size : tiny
     span    : auto
+    trans: true
     comment : The optimal length is 155
     placeholder: Defaults to SEO if left blank
 


### PR DESCRIPTION
With translation mechanism is that it listens the backend.form.extendFieldsBefore event for form and then register fields for translation. When we try to register new fields in form using extendFormFields extension, It happens afterward so new added fields are not visible to translation listener. so they are kind of skipped as translation field registration process already been done. 

- https://stackoverflow.com/questions/58641718

Fixed #9 
